### PR TITLE
 support request header & fix deploy bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "staticmaps",
-  "version": "0.7.2",
+  "version": "0.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -912,7 +912,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
@@ -1222,8 +1221,7 @@
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-      "dev": true
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3763,8 +3761,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/StephanGeorg/staticmaps#readme",
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "gm": "^1.23.0",
     "jimp": "^0.2.27",
     "lodash.chunk": "^4.2.0",

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -35,6 +35,7 @@ class StaticMaps {
     this.tileUrl = this.options.tileUrl || 'http://tile.openstreetmap.org/{z}/{x}/{y}.png';
     this.tileSize = this.options.tileSize || 256;
     this.tileRequestTimeout = this.options.tileRequestTimeout;
+    this.tileRequestHeader = this.options.tileRequestHeader;
     this.reverseY = this.options.reverseY || false;
 
     // # features
@@ -360,6 +361,8 @@ class StaticMaps {
       };
 
       if (this.tileRequestTimeout) options.timeout = this.tileRequestTimeout;
+
+      if (this.tileRequestHeader) options.headers = this.tileRequestHeader;
 
       request.get(options).then((res) => {
         resolve({


### PR DESCRIPTION
### support request header
I use the google map tile, he must use the user agent in the headers, otherwise it will return a 403 error.

```
https://mt1.google.cn/vt/lyrs=m@207000000&hl=zh-CN&gl=CN&src=app&x={x}&y={y}&z={z}&s=Galile
```

### fix deploy bug
I deployed the source code to the server, but I get an error when I enable it.
```
error: Cannot find module 'babel-runtime/regenerator'
```
I found the babel documentation https://babeljs.io/docs/en/babel-plugin-transform-runtime#installation to fix this error.
