### PR TITLE
Sharp usage feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A node.js library for creating map images with polylines and markers. This libra
 
 Image manupulation is based on [GraphicsMagick](http://www.graphicsmagick.org/). You can also use
 [ImageMagick](https://www.imagemagick.org/script/download.php) or [Sharp](http://sharp.pixelplumbing.com/en/stable/install) by adding ``imageMagick: true`` or ``sharp: true`` to
-the initialization options. **Install [GraphicsMagick](http://www.graphicsmagick.org/README.html#installation), [ImageMagick](hhttps://www.imagemagick.org/script/download.php) or [Sharp](http://sharp.pixelplumbing.com/en/stable/install/) first.**
+the initialization options. **Install [GraphicsMagick](http://www.graphicsmagick.org/README.html#installation), [ImageMagick](https://www.imagemagick.org/script/download.php) or [Sharp](http://sharp.pixelplumbing.com/en/stable/install/) first.**
 
 ```bash
 > npm i staticmaps

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A node.js library for creating map images with polylines and markers. This libra
 ## Installation
 
 Image manupulation is based on [GraphicsMagick](http://www.graphicsmagick.org/). You can also use
-[ImageMagick](https://www.imagemagick.org/script/download.php) by adding ``imageMagick: true`` to
-the initialization options. **Install [GraphicsMagick](http://www.graphicsmagick.org/README.html#installation) or [ImageMagick](https://www.imagemagick.org/script/download.php) first.**
+[ImageMagick](https://www.imagemagick.org/script/download.php) or [Sharp](http://sharp.pixelplumbing.com/en/stable/install) by adding ``imageMagick: true`` or ``sharp: true`` to
+the initialization options. **Install [GraphicsMagick](http://www.graphicsmagick.org/README.html#installation), [ImageMagick](hhttps://www.imagemagick.org/script/download.php) or [Sharp](http://sharp.pixelplumbing.com/en/stable/install/) first.**
 
 ```bash
 > npm i staticmaps
@@ -38,6 +38,7 @@ tileSize            | (optional) Tile size in pixel (default: 256)
 tileRequestTimeout  | (optional) Timeout for the tiles request
 tileRequestHeader   | (optional) Additional headers for the tiles request (default: {})
 imageMagick         | (optional) Use ImageMagick instead of GraphicsMagick (default: false)
+sharp               | (optional) Use sharp instead of GraphicsMagick (default: false)
 
 ### Methods
 #### addMarker (options)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Adds a marker to the map.
 ##### Marker options
 Parameter           | Description
 ------------------- | -------------
-coords              | Coordinates of the marker ([Lng, Lat])
+coord               | Coordinates of the marker ([Lng, Lat])
 img                 | Marker image path or URL
 height              | Height of the marker image
 width               | Width of the marker image

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Adds a marker to the map.
 ##### Marker options
 Parameter           | Description
 ------------------- | -------------
-coord               | Coordinates of the marker ([Lng, Lat])
+coords              | Coordinates of the marker ([Lng, Lat])
 img                 | Marker image path or URL
 height              | Height of the marker image
 width               | Width of the marker image
@@ -70,7 +70,7 @@ Adds a polyline to the map.
 ##### Polyline options
 Parameter           | Description
 ------------------- | -------------
-coord               | Coordinates of the polyline ([[Lng, Lat], ... ,[Lng, Lat]])
+coords              | Coordinates of the polyline ([[Lng, Lat], ... ,[Lng, Lat]])
 color               | Stroke color of the polyline (Default: '#000000BB')
 width               | Stroke width of the polyline (Default: 3)
 simplify            | TODO
@@ -98,7 +98,7 @@ map.addPolygon(options);
 ##### Polygon options
 Parameter           | Description
 ------------------- | -------------
-coord               | Coordinates of the polygon ([[Lng, Lat], ... ,[Lng, Lat]])
+coords              | Coordinates of the polygon ([[Lng, Lat], ... ,[Lng, Lat]])
 color               | Stroke color of the polygon (Default: '#000000BB')        
 width               | Stroke width of the polygon (Default: 3)
 fill                | Fill color of the polygon (Default: '#000000BB')

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "lodash.last": "^3.0.0",
     "lodash.uniqby": "^4.7.0",
     "request": "^2.79.0",
-    "request-promise": "^4.1.1"
+    "request-promise": "^4.1.1",
+    "sharp": "^0.20.7"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.2",
+    "babel-eslint": "^9.0.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
@@ -53,7 +55,7 @@
     "chai": "^4.1.2",
     "eslint": "^5.1.0",
     "eslint-config-airbnb-base": "^13.0.0",
-    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-import": "^2.14.0",
     "mocha": "^4.0.1"
   },
   "babel": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chai": "^4.1.2",
     "eslint": "^5.1.0",
     "eslint-config-airbnb-base": "^13.0.0",
-    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-import": "^2.13.0",
     "mocha": "^4.0.1"
   },
   "babel": {

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -278,14 +278,15 @@ class StaticMaps {
 
         if (type === 'polyline') {
           if (this.sharp) {
-            // if Sharp used for drawing polygon
-            this.sharp(result)
+            // if Sharp used for drawing polyline
+            const sharpImage = this.sharp(result);
+            sharpImage
               .metadata()
               .then((imageMetadata) => {
                 const svgPath = `<svg width="${imageMetadata.width}px" height="${imageMetadata.height}" version="1.1" xmlns="http://www.w3.org/2000/svg">`
                   + `<polyline points="${points.join(' ')}" stroke="${line.color}" fill="none" stroke-width="${line.width}"/>`
                   + '</svg>';
-                this.sharp(result)
+                sharpImage
                   .overlayWith(Buffer.from(svgPath), { top: 0, left: 0 })
                   .toBuffer()
                   .then((buffer) => {
@@ -299,7 +300,7 @@ class StaticMaps {
               })
               .catch(reject);
           } else {
-            // if GraphicsMagick/ImageMagick used for drawing polygon
+            // if GraphicsMagick/ImageMagick used for drawing polyline
             this.gm(result)
               .fill(0)
               .stroke(line.color, line.width)
@@ -316,13 +317,14 @@ class StaticMaps {
         } else if (type === 'polygon') {
           if (this.sharp) {
             // if Sharp used for drawing polygon
-            this.sharp(result)
+            const sharpImage = this.sharp(result);
+            sharpImage
               .metadata()
               .then((imageMetadata) => {
                 const svgPath = `<svg width="${imageMetadata.width}px" height="${imageMetadata.height}" version="1.1" xmlns="http://www.w3.org/2000/svg">`
                   + `<polygon style="fill-rule: evenodd;" points="${points.join(' ')}" stroke="${line.color}" fill="${line.fill}" stroke-width="${line.width}"/>`
                   + '</svg>';
-                this.sharp(result)
+                sharpImage
                   .overlayWith(Buffer.from(svgPath), { top: 0, left: 0 })
                   .toBuffer()
                   .then((buffer) => {

--- a/test/staticmaps-gm.js
+++ b/test/staticmaps-gm.js
@@ -144,7 +144,7 @@ describe('StaticMap', () => {
       map.addLine(polyline2);
       map.addLine(polyline);
       map.render()
-        .then(() => map.image.save('test/out/06-polyline.jpg'))
+        .then(() => map.image.save('test/out/06-polyline-gm.jpg'))
         .then(done)
         .catch(done);
     }).timeout(0);
@@ -167,7 +167,7 @@ describe('StaticMap', () => {
 
       map.addPolygon(polygon);
       map.render()
-        .then(() => map.image.save('test/out/07-polygon.png'))
+        .then(() => map.image.save('test/out/07-polygon-gm.png'))
         .then(done)
         .catch(done);
     }).timeout(5000);

--- a/test/staticmaps-sharp.js
+++ b/test/staticmaps-sharp.js
@@ -8,8 +8,8 @@ const { expect } = require('chai');
 
 const markerPath = path.join(__dirname, 'marker.png');
 
-describe('StaticMap w/ ImageMagick', () => {
-  describe('Rendering w/ lines by ImageMagick...', () => {
+describe('StaticMap w/ Sharp', () => {
+  describe('Rendering w/ lines by Sharp...', () => {
     it('Render StaticMap w/ single polyline', (done) => {
       const options = {
         width: 800,
@@ -17,7 +17,7 @@ describe('StaticMap w/ ImageMagick', () => {
         paddingX: 0,
         paddingY: 0,
         quality: 10,
-        imageMagick: true
+        sharp: true
       };
 
       const map = new StaticMaps(options);
@@ -38,7 +38,7 @@ describe('StaticMap w/ ImageMagick', () => {
       map.addLine(polyline2);
       map.addLine(polyline);
       map.render()
-        .then(() => map.image.save('test/out/06-polyline-im.jpg'))
+        .then(() => map.image.save('test/out/06-polyline-sharp.jpg'))
         .then(done)
         .catch(done);
     }).timeout(10000);
@@ -49,7 +49,7 @@ describe('StaticMap w/ ImageMagick', () => {
         height: 300,
         paddingX: 50,
         paddingY: 50,
-        imageMagick: true
+        sharp: true
       };
 
       const map = new StaticMaps(options);
@@ -62,7 +62,7 @@ describe('StaticMap w/ ImageMagick', () => {
 
       map.addPolygon(polygon);
       map.render()
-        .then(() => map.image.save('test/out/07-polygon-im.png'))
+        .then(() => map.image.save('test/out/07-polygon-sharp.png'))
         .then(done)
         .catch(done);
     }).timeout(10000);


### PR DESCRIPTION
Hi! It's me again.

Earlier I added support for ImageMagick for drawing polygons and polylines.

In my projects, I also sometimes use a library called Sharp. You can find out more about it here: http://sharp.pixelplumbing.com/en/stable/. Its main advantage over ImageMagick and GraphicsMagick is its speed (http://sharp.pixelplumbing.com/en/stable/performance/).

However, this library does not contain a function for drawing lines and polygons, so I used the svg overlay on the map image. This does not lead to a serious increase in rendering speed, but allows you to get rid of the need to use ImageMagick and GraphicsMagick if there is a Sharp available.

Also in this pull request, I made some changes to the tests. I added suffixes -gm, -im, -sharp to filenames in polygon and polyline tests. By the way, this made it possible to notice some differences in the transparency of the filling of polygons.

Tests for sharp are also included.