### PR TITLE
Ignore missing tiles and add zoomRange option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,18 @@ const options = {
 const map = new StaticMaps(options);
 ```
 #### Map options
-Parameter           | Default   | Description
-------------------- | --------- | -------------
-width               | Required  | Width of the output image in px
-height              | Required  | Height of the output image in px
-paddingX            | 0         | (optional) Minimum distance in px between map features and map border
-paddingY            | 0         | (optional) Minimum distance in px between map features and map border
-tileUrl             |           | (optional) Tile server URL for the map base layer
-tileSize            | 256       | (optional) Tile size in pixel
-tileRequestTimeout  |           | (optional) Timeout for the tiles request
-tileRequestHeader   | {}        | (optional) Additional headers for the tiles request (default: {})
-maxZoom             |           | (optional) If defined, forces zoom to stay at least this far from the surface, useful for tile servers that error on high levels
-zoomRange           | { min: 1, max: 23} | (optional) If defined, defines the range of zoom levels to try
+Parameter           | Default            | Description
+------------------- | ------------------ | -------------
+width               | Required           | Width of the output image in px
+height              | Required           | Height of the output image in px
+paddingX            | 0                  | (optional) Minimum distance in px between map features and map border
+paddingY            | 0                  | (optional) Minimum distance in px between map features and map border
+tileUrl             |                    | (optional) Tile server URL for the map base layer
+tileSize            | 256                | (optional) Tile size in pixel
+tileRequestTimeout  |                    | (optional) Timeout for the tiles request
+tileRequestHeader   | {}                 | (optional) Additional headers for the tiles request (default: {})
+maxZoom             |                    | (optional) If defined, forces zoom to stay at least this far from the surface, useful for tile servers that error on high levels
+zoomRange           | { min: 1, max: 17} | (optional) If defined, defines the range of zoom levels to try
 
 ### Methods
 #### addMarker (options)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ tileSize            | 256       | (optional) Tile size in pixel
 tileRequestTimeout  |           | (optional) Timeout for the tiles request
 tileRequestHeader   | {}        | (optional) Additional headers for the tiles request (default: {})
 maxZoom             |           | (optional) If defined, forces zoom to stay at least this far from the surface, useful for tile servers that error on high levels
+zoomRange           | { min: 1, max: 23} | (optional) If defined, defines the range of zoom levels to try
 
 ### Methods
 #### addMarker (options)

--- a/src/image.js
+++ b/src/image.js
@@ -33,7 +33,7 @@ export default class Image {
 
           // Fixed #20 https://github.com/StephanGeorg/staticmaps/issues/20
           if (!w || !h) {
-            resolve(null);
+            resolve({ success: false });
             return null;
           }
 
@@ -47,11 +47,14 @@ export default class Image {
             .toBuffer()
             .then((part) => {
               resolve({
+                success: true,
                 position: { top: Math.round(sy), left: Math.round(sx) },
                 data: part,
               });
-            });
-        });
+            })
+            .catch(() => resolve({ success: false }));
+        })
+        .catch(() => resolve({ success: false }));
     });
   }
 
@@ -76,7 +79,7 @@ export default class Image {
       tiles.forEach((tile, i) => {
         tileParts.push(this.prepareTileParts(tile, i));
       });
-      const preparedTiles = await Promise.all(tileParts);
+      const preparedTiles = (await Promise.all(tileParts)).filter(v => v.success);
 
       // Compose all prepared tiles to the baselayer
       const queue = [];

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -40,7 +40,7 @@ class StaticMaps {
     this.tileRequestHeader = this.options.tileRequestHeader;
     this.reverseY = this.options.reverseY || false;
     this.maxZoom = this.options.maxZoom;
-    this.zoomRange = this.options.zoomRange || { min: 1, max: 23 };
+    this.zoomRange = this.options.zoomRange || { min: 1, max: 17 };
 
     // # features
     this.markers = [];

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -222,12 +222,9 @@ class StaticMaps {
 
     const tilePromises = [];
     result.forEach((r) => { tilePromises.push(this.getTile(r)); });
-    const toResultObject = promise => promise
-      .then(tile => ({ success: true, tile }))
-      .catch(error => ({ success: false, error }));
 
     return new Promise((resolve, reject) => {
-      Promise.all(tilePromises.map(toResultObject))
+      Promise.all(tilePromises)
         .then(values => this.image.draw(values.filter(v => v.success).map(v => v.tile)))
         .then(resolve)
         .catch(reject);
@@ -429,7 +426,7 @@ class StaticMaps {
    *  Fetching tiles from endpoint
    */
   getTile(data) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const options = {
         url: data.url,
         encoding: null,
@@ -443,11 +440,17 @@ class StaticMaps {
 
       request.get(options).then((res) => {
         resolve({
-          url: data.url,
-          box: data.box,
-          body: res.body,
+          success: true,
+          tile: {
+            url: data.url,
+            box: data.box,
+            body: res.body,
+          },
         });
-      }).catch(reject);
+      }).catch(error => resolve({
+        success: false,
+        error,
+      }));
     });
   }
 }


### PR DESCRIPTION
First of all, thank you for this very handy tool 🎉 

In our application we have tiles that could be missing and we just want to ignore them (ie render a partly transparent image). We implemented this by ignoring the errors when loading tiles. Maybe it's cleaner to only catch the not found errors? 

The maximum zoom level of 17 was not sufficient for our application. Instead of just increasing it to 23 I added an option to specify the range to scan. We can then see which levels we have available on our storage and give that as a range to StaticMaps.