### PR TITLE
Remove Array prototype

### DIFF
--- a/src/helper/helper.js
+++ b/src/helper/helper.js
@@ -1,6 +1,0 @@
-Array.prototype.max = function () {
-  return Math.max.apply(null, this);
-};
-Array.prototype.min = function () {
-  return Math.min.apply(null, this);
-};

--- a/src/polyline.js
+++ b/src/polyline.js
@@ -20,10 +20,10 @@ export default class Polyline {
    */
   extent() {
     return [
-      this.coords.map(c => c[0]).min(),
-      this.coords.map(c => c[1]).min(),
-      this.coords.map(c => c[0]).max(),
-      this.coords.map(c => c[1]).max(),
+      Math.min(...this.coords.map(c => c[0])),
+      Math.min(...this.coords.map(c => c[1])),
+      Math.max(...this.coords.map(c => c[0])),
+      Math.max(...this.coords.map(c => c[1])),
     ];
   }
 }

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -12,8 +12,6 @@ import Text from './text';
 import asyncQueue from './helper/asyncQueue';
 import pjson from '../package.json';
 
-require('./helper/helper');
-
 /* transform longitude to tile number */
 const lonToX = (lon, zoom) => ((lon + 180) / 360) * (2 ** zoom);
 /* transform latitude to tile number */
@@ -151,10 +149,10 @@ class StaticMaps {
     }
 
     return [
-      extents.map(e => e[0]).min(),
-      extents.map(e => e[1]).min(),
-      extents.map(e => e[2]).max(),
-      extents.map(e => e[3]).max(),
+      Math.min(...extents.map(e => e[0])),
+      Math.min(...extents.map(e => e[1])),
+      Math.max(...extents.map(e => e[2])),
+      Math.max(...extents.map(e => e[3])),
     ];
   }
 


### PR DESCRIPTION
Thanks for the awesome library!

Extending Array.prototype caused problems when using staticmaps in combination with other libraries. I removed the min and max functions in the prototype and replaced them by the standard Math.min and Math.max functions.