### PR TITLE
Support subdomains in tile url

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ paddingX            | 0                   | (optional) Minimum distance in px be
 paddingY            | 0                   | (optional) Minimum distance in px between map features and map border
 tileUrl             |                     | (optional) Tile server URL for the map base layer
 tileSize            | 256                 | (optional) Tile size in pixel
+subdomains          | []                  | (optional) Subdomains of tile server, usage ['a', 'b', 'c']
 tileRequestTimeout  |                     | (optional) Timeout for the tiles request
 tileRequestHeader   | {}                  | (optional) Additional headers for the tiles request (default: {})
 tileRequestLimit    | 2                   | (optional) Limit concurrent connections to the tiles server
@@ -336,7 +337,7 @@ const options = {
     width: 1200,
     height: 800,
     tileUrl: 'https://map1.vis.earthdata.nasa.gov/wmts-webmerc/BlueMarble_NextGeneration/default/GoogleMapsCompatible_Level8/{z}/{y}/{x}.jpg',
-    zoomRange {
+    zoomRange: {
       max: 8, // NASA server does not support level 9 or higher
     }
   };
@@ -360,6 +361,22 @@ const options = {
 
 #### Output
 ![NASA Blue Marble with text](https://i.imgur.com/Jb6hsju.jpg)
+
+### Tile server with subdomains
+{s} - subdomain (subdomain), is necessary in order not to fall into the limit for requests to the same domain. Some servers can block your IP if you get tiles from one of subdomains of tile server.
+```javascript
+const options = {
+    width: 1024,
+    height: 1024,
+    subdomains: ['a', 'b', 'c'],
+    tileUrl: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+};
+
+const map = new StaticMaps(options);
+
+map.render([13.437524, 52.4945528], 13)
+.then(() => map.image.save('test/out/subdomains.png'));
+```
 
 # Contributers
 

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -217,17 +217,15 @@ class StaticMaps {
         let tileY = (y + maxTile) % maxTile;
         if (this.reverseY) tileY = ((1 << this.zoom) - tileY) - 1;
 
-        let url = this.tileUrl.replace('{z}', this.zoom).replace('{x}', tileX).replace('{y}', tileY)
+        let tileUrl = this.tileUrl.replace('{z}', this.zoom).replace('{x}', tileX).replace('{y}', tileY);
 
-        if(this.subdomains.length > 0) {
+        if (this.subdomains.length > 0) {
           // replace subdomain with random domain from subdomains array
-          url = url.replace('{s}', this.subdomains[Math.floor(Math.random() * this.subdomains.length)])
+          tileUrl = tileUrl.replace('{s}', this.subdomains[Math.floor(Math.random() * this.subdomains.length)]);
         }
 
-        console.log(url)
-
         result.push({
-          url,
+          url: tileUrl,
           box: [
             this.xToPx(x),
             this.yToPx(y),

--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -37,6 +37,7 @@ class StaticMaps {
     this.padding = [this.paddingX, this.paddingY];
     this.tileUrl = this.options.tileUrl || 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
     this.tileSize = this.options.tileSize || 256;
+    this.subdomains = this.options.subdomains || [];
     this.tileRequestTimeout = this.options.tileRequestTimeout;
     this.tileRequestHeader = this.options.tileRequestHeader;
     this.tileRequestLimit = this.options.tileRequestLimit || 2;
@@ -216,8 +217,17 @@ class StaticMaps {
         let tileY = (y + maxTile) % maxTile;
         if (this.reverseY) tileY = ((1 << this.zoom) - tileY) - 1;
 
+        let url = this.tileUrl.replace('{z}', this.zoom).replace('{x}', tileX).replace('{y}', tileY)
+
+        if(this.subdomains.length > 0) {
+          // replace subdomain with random domain from subdomains array
+          url = url.replace('{s}', this.subdomains[Math.floor(Math.random() * this.subdomains.length)])
+        }
+
+        console.log(url)
+
         result.push({
-          url: this.tileUrl.replace('{z}', this.zoom).replace('{x}', tileX).replace('{y}', tileY),
+          url,
           box: [
             this.xToPx(x),
             this.yToPx(y),

--- a/test/staticmaps.js
+++ b/test/staticmaps.js
@@ -275,4 +275,22 @@ describe('StaticMap', () => {
         .catch(done);
     }).timeout(0);
   });
+
+  describe('Fetch tiles from subdomains', () => {
+    it('should fetch from subdomains', (done) => {
+      const options = {
+        width: 1024,
+        height: 1024,
+        subdomains: ['a', 'b', 'c'],
+        tileUrl: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      };
+
+      const map = new StaticMaps(options);
+
+      map.render([13.437524, 52.4945528], 13)
+        .then(() => map.image.save('test/out/10-subdomains.png'))
+        .then(done)
+        .catch(done);
+    }).timeout(0);
+  });
 });


### PR DESCRIPTION
Added support for subdomains, some servers block you if you request many times to one server. 

![image](https://user-images.githubusercontent.com/10253982/79036615-76413900-7be3-11ea-9f35-8ef8f11a6767.png)
https://habr.com/ru/post/283354/

I could not find anything in english, but in image above said 
> {s} - subdomain (subdomain), is necessary in order not to fall into the browser limit for requests to the same domain. Empirically, it was possible to calculate that it is 01, 02, 03, 04

Some tile servers block you ip if you request tiles from only one of the subdomains of server. In order not to hit that limit we need randomly choose one of the subdomains. 
Currently, I am developing app which requires map generation with markers and polygons. I have faced  this issue in the past so decide open PR.