### PR TITLE
Fix: Pass in response body when fetching remote url for marker.

### DIFF
--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -390,7 +390,7 @@ class StaticMaps {
               url: icon.file,
               responseType: 'buffer',
             });
-            icon.data = await sharp(img).toBuffer();
+            icon.data = await sharp(img.body).toBuffer();
           } else {
             // Load marker from local fs
             icon.data = await sharp(icon.file).toBuffer();

--- a/test/staticmaps.js
+++ b/test/staticmaps.js
@@ -91,6 +91,34 @@ describe('StaticMap', () => {
         .catch(done);
     }).timeout(0);
 
+    it('render w/ remote url icon', (done) => {
+      const options = {
+        width: 500,
+        height: 500,
+      };
+
+      const map = new StaticMaps(options);
+
+      const marker = {
+        img: "https://img.icons8.com/color/48/000000/marker.png",
+        offsetX: 24,
+        offsetY: 48,
+        width: 48,
+        height: 48,
+      };
+
+      marker.coord = [13.437524, 52.4945528];
+      map.addMarker(marker);
+
+      marker.coord = [13.430524, 52.4995528];
+      map.addMarker(marker);
+
+      map.render([13.437524, 52.4945528], 12)
+        .then(() => map.image.save('test/out/04-marker.png'))
+        .then(done)
+        .catch((err) => { console.log(err)});
+    }).timeout(0);
+
     it('render w/out center', (done) => {
       const options = {
         width: 1200,


### PR DESCRIPTION
Before:
Currently we try and pass the response object into sharp when using a remote url for any markers which leads to an error from sharp `[Error: Input file is missing]`.

<img width="590" alt="Screen Shot 2020-05-21 at 2 02 51 PM" src="https://user-images.githubusercontent.com/5448346/82591071-c0b3bf00-9b6c-11ea-8f9f-2fbbc632237e.png">

After:
Properly pass in response body which is a buffer that sharp accepts as an argument. Included a test to use a remote url for a marker which passes the test.

<img width="586" alt="Screen Shot 2020-05-21 at 2 12 25 PM" src="https://user-images.githubusercontent.com/5448346/82591331-2dc75480-9b6d-11ea-9271-c2848fd39839.png">
