### PR TITLE
Allow drawing empty base layer

### DIFF
--- a/src/staticmaps.js
+++ b/src/staticmaps.js
@@ -27,7 +27,7 @@ class StaticMaps {
     this.paddingX = this.options.paddingX || 0;
     this.paddingY = this.options.paddingY || 0;
     this.padding = [this.paddingX, this.paddingY];
-    this.tileUrl = this.options.tileUrl || 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+    this.tileUrl = 'tileUrl' in this.options ? this.options.tileUrl : 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
     this.tileSize = this.options.tileSize || 256;
     this.subdomains = this.options.subdomains || [];
     this.tileRequestTimeout = this.options.tileRequestTimeout;
@@ -228,6 +228,10 @@ class StaticMaps {
   }
 
   async drawBaselayer() {
+    if (!this.tileUrl) {
+      // Early return if we shouldn't draw a base layer
+      return this.image.draw([]);
+    }
     const xMin = Math.floor(this.centerX - (0.5 * this.width / this.tileSize));
     const yMin = Math.floor(this.centerY - (0.5 * this.height / this.tileSize));
     const xMax = Math.ceil(this.centerX + (0.5 * this.width / this.tileSize));

--- a/test/staticmaps.js
+++ b/test/staticmaps.js
@@ -135,6 +135,57 @@ describe('StaticMap', () => {
       await map.render();
       await map.image.save('test/out/05-marker-nocenter.png');
     }).timeout(0);
+
+    it('render w/out base layer', async () => {
+      const options = {
+        width: 800,
+        height: 800,
+        paddingX: 0,
+        paddingY: 0,
+        quality: 10,
+        tileUrl: undefined,
+      };
+      const map = new StaticMaps(options);
+
+      const coords = Route.routes[0].geometry.coordinates;
+
+      const marker = {
+        img: markerPath,
+        offsetX: 24,
+        offsetY: 48,
+        width: 48,
+        height: 48,
+      };
+      [marker.coord] = coords;
+      map.addMarker(marker);
+      marker.coord = coords[coords.length - 1];
+      map.addMarker(marker);
+
+      const polyline = {
+        coords,
+        color: '#0000FF66',
+        width: 3,
+      };
+      map.addLine(polyline);
+
+      const text = {
+        coord: coords[Math.round(coords.length / 2)],
+        offsetX: 100,
+        offsetY: 50,
+        text: 'TEXT',
+        size: 50,
+        width: '1px',
+        fill: '#000000',
+        color: '#ffffff',
+        font: 'Impact',
+        anchor: 'middle',
+      };
+
+      map.addText(text);
+
+      await map.render();
+      await map.image.save('test/out/05-annotations-nobaselayer.png');
+    }).timeout(0);
   });
 
   describe('Rendering w/ polylines ...', () => {


### PR DESCRIPTION
We have a special use-case where it's useful to allow drawing annotations without having a base-layer.

Some of our map layers have thermal data meaning that the data is encoded in the RGB values of the tiles and has to be decoded to a visual coloring again. We draw the base layer using staticmaps, read the resulting image and apply the coloring to the pixels. 

When adding drawings (lines, polygons, text, ...) this would mean that the drawings get this different coloring too. That's why we render them separately with a staticmaps instance without base layer and in the end add it as an overlay to the colored map layer (using sharp).