### PR TITLE
Fix example of addCircle in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ fill                | #000000BB | Fill color of the multipolygon
 #### addCircle (options)
 Adds a circle to the map.
 ```
-map.addPolygon(options);
+map.addCircle(options);
 ```
-##### Polygon options
+##### Circle options
 Parameter           | Default   | Description
 ------------------- | --------- | -------------
 coord               | Required  | Coordinate of center of circle


### PR DESCRIPTION
change

#### addCircle (options)
Adds a circle to the map.
```
map.addPolygon(options);
```
##### Polygon options

to

#### addCircle (options)
Adds a circle to the map.
```
map.addCircle(options);
```
##### Circle options